### PR TITLE
Add Korean clone messages

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/ReadTag.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/ReadTag.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.SparseArray;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -47,6 +48,7 @@ public class ReadTag extends AppCompatActivity {
 
     private final Handler mHandler = new Handler(Looper.getMainLooper());
     private SparseArray<String[]> mRawDump;
+    private TextView mReadStatus;
 
     /**
      * Show the {@link KeyMapCreator}.
@@ -55,6 +57,10 @@ public class ReadTag extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_read_tag);
+        mReadStatus = findViewById(R.id.textViewReadTag);
+        mReadStatus.setText(R.string.text_hold_existing_card);
+        Toast.makeText(this, R.string.text_hold_existing_card,
+                Toast.LENGTH_SHORT).show();
 
         Intent intent = new Intent(this, KeyMapCreator.class);
         intent.putExtra(KeyMapCreator.EXTRA_KEYS_DIR,
@@ -143,6 +149,11 @@ public class ReadTag extends AppCompatActivity {
                 Intent intent = new Intent(this, DumpEditor.class);
                 intent.putExtra(DumpEditor.EXTRA_DUMP, dump);
                 startActivity(intent);
+                if (mReadStatus != null) {
+                    mReadStatus.setText(R.string.text_copy_step1);
+                }
+                Toast.makeText(this, R.string.text_copy_step1,
+                        Toast.LENGTH_SHORT).show();
             } else {
                 // Error, keys from key map are not valid for reading.
                 Toast.makeText(this, R.string.info_none_key_valid_for_reading,

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/WriteTag.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/WriteTag.java
@@ -110,6 +110,9 @@ public class WriteTag extends BasicActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_write_tag);
 
+        Toast.makeText(this, R.string.text_modukey_present,
+                Toast.LENGTH_SHORT).show();
+
         mSectorTextBlock = findViewById(R.id.editTextWriteTagSector);
         mBlockTextBlock = findViewById(R.id.editTextWriteTagBlock);
         mDataText = findViewById(R.id.editTextWriteTagData);
@@ -1215,6 +1218,9 @@ public class WriteTag extends BasicActivity {
             return;
         }
 
+        Toast.makeText(this, R.string.text_copy_step2,
+                Toast.LENGTH_SHORT).show();
+
         // Create reader.
         final MCReader reader = Common.checkForTagAndCreateReader(this);
         if (reader == null) {
@@ -1231,7 +1237,7 @@ public class WriteTag extends BasicActivity {
         pad = Common.dpToPx(20);
         progressBar.setPadding(0, 0, pad, 0);
         TextView tv = new TextView(this);
-        tv.setText(getString(R.string.dialog_wait_write_tag));
+        tv.setText(getString(R.string.text_copy_step2));
         tv.setTextSize(18);
         ll.addView(progressBar);
         ll.addView(tv);

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -673,6 +673,12 @@
     <string name="hint_custom_retry_authentication_count">Number of retries</string>
     <string name="hint_key">HEX, 6 bytes per line</string>
 
+    <!-- Copy/Clone wizard messages -->
+    <string name="text_hold_existing_card">기존 카드를 기기에 대십시오</string>
+    <string name="text_copy_step1">원본 카드 읽기 완료</string>
+    <string name="text_modukey_present">모두키 카드를 기기에 대십시오</string>
+    <string name="text_copy_step2">카드에 쓰는 중…</string>
+
     <!-- Supported locales. No need for translation! -->
     <string-array name="supported_locales" translatable="false">
         <item>English (en)</item>


### PR DESCRIPTION
## Summary
- add Korean copy/clone strings
- show localized clone prompts in `ReadTag` and `WriteTag`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e67bf7e4832cb4c176b87347eb70