### PR TITLE
Add Korean strings and ModuKey layout

### DIFF
--- a/Mifare Classic Tool/app/src/main/res/layout/activity_modukey.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_modukey.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/textHoldExistingCard"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/text_hold_existing_card" />
+
+    <TextView
+        android:id="@+id/textModukeyPresent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/text_modukey_present" />
+
+    <TextView
+        android:id="@+id/textCopyStep"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/text_copy_step1" />
+
+    <Button
+        android:id="@+id/buttonStartCopy"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/action_start_copy" />
+
+    <Button
+        android:id="@+id/buttonStartCopyStep2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/action_start_copy_step2" />
+
+</LinearLayout>

--- a/Mifare Classic Tool/app/src/main/res/values-ko/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MIFARE 클래식 툴</string>
+    <string name="app_version">앱 버전</string>
+    <string name="text_hold_existing_card">기존 카드키를 스마트폰 뒷면에 인식한 채로 유지하세요</string>
+    <string name="text_modukey_present">모두키를 스마트폰 뒷면에 인식시켜주세요</string>
+    <string name="text_copy_step1">복사1단계 진행중</string>
+    <string name="text_copy_step2">복사2단계 진행중</string>
+    <string name="action_start_copy">복사시작</string>
+    <string name="action_start_copy_step2">복사2단계 시작</string>
+</resources>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -662,6 +662,12 @@
         NXP\'s specifications.
         \n\nProceed at your own risk!</string>
 
+    <string name="text_hold_existing_card">Hold the existing key card on the back of your phone</string>
+    <string name="text_modukey_present">Present the ModuKey on the back of your phone</string>
+    <string name="text_copy_step1">Copy step 1 in progress</string>
+    <string name="text_copy_step2">Copy step 2 in progress</string>
+    <string name="action_start_copy">Start Copy</string>
+    <string name="action_start_copy_step2">Start Copy Step 2</string>
     <!-- Hints -->
     <string name="hint_hex_16_byte">HEX, 16 bytes (e.g. 0A4F&#8230;)</string>
     <string name="hint_hex_3_byte">HEX, 3 bytes</string>


### PR DESCRIPTION
## Summary
- add Korean resources for ModuKey workflow
- insert new ModuKey strings in default resources
- create a small layout referencing the new strings

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6842e667db50832cb83689d5de4af5cb