### PR TITLE
Add ModuKey cloning info and Korean support

### DIFF
--- a/Mifare Classic Tool/app/src/main/assets/help/help.html
+++ b/Mifare Classic Tool/app/src/main/assets/help/help.html
@@ -91,6 +91,7 @@
     basic familiarity with the MIFARE Classic technology.
     You also need an understanding of the hexadecimal number system,
     because all data input and output is in hexadecimal.
+    The user interface is available in multiple languages, including Korean.
     <br /><br />
     Some important things are:
     <ul>
@@ -158,6 +159,7 @@
       <li>Quick UID clone feature</li>
       <li>Import/export/convert files</li>
       <li>In-App (offline) help and information</li>
+<li>Korean language support</li>
       <li>It's open source ;)</li>
     </ul>
 
@@ -309,6 +311,8 @@
     After selecting the dump, the sectors, and the key files, the App will check
     everything for you! If there are issues like 'block is read-only', 'key
     with write access not known', etc., you will get a report before writing.
+    ModuKey cloning is done in two steps. First, use <b>Write Dump (Clone)</b> with the <i>Write to Manufacturer Block</i> option enabled to load the ModuKey template. After writing completes, press the hardware button on the ModuKey to finalize.
+
     <br><br>
     <b>Options:</b>
     <ul>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An Android NFC app for reading, writing, analyzing, etc. MIFARE Classic RFID tag
 Read this information in other languages:
 * [English](README.md)
 * [简体中文](README.zh-CN.md)
+* Korean language support in the app UI
 
 Helpful links:
 * [MIFARE Classic Tool (Donate Version) on Google Play](https://play.google.com/store/apps/details?id=de.syss.MifareClassicToolDonate)
@@ -36,6 +37,7 @@ Features
   See chapter [Getting Started](#getting-started).
 * Format a tag back to the factory/delivery state
 * Write the manufacturer block (block 0) of special MIFARE Classic tags
+* Support two-step ModuKey cloning workflow
 * Use external NFC readers like ACR 122U  
   (See the [Help & Info section](https://publications.icaria.de/mct/help-and-info/#external_nfc)
   for more information.)
@@ -52,6 +54,7 @@ Features
 * Quick UID clone feature
 * Import/export/convert files
 * In-App (offline) help and information
+* Korean language support
 * It's free software (open source) ;)
 
 
@@ -96,6 +99,10 @@ Some important things are:
   Also, make sure the BCC value (check out the "BCC Calculator Tool"),
   the SAK and the ATQA values are correct. If you just want to clone a UID,
   please use the "Clone UID Tool".
+ModuKey cards are cloned in two steps:
+1. Use **Write Dump (Clone)** with "Write to Manufacturer Block" enabled to load the ModuKey template.
+2. After writing completes, press the ModuKey button to finalize the data.
+
 * This app **will not work** on some devices because their hardware
   (NFC-controller) does not support MIFARE Classic
   ([read more](https://github.com/ikarus23/MifareClassicTool/issues/1)).


### PR DESCRIPTION
## Summary
- document Korean language support
- describe the two-step ModuKey cloning process in README and help

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_6842e6839064832caf2272d7bda06ee1