### PR TITLE
Fix duplicate string resource

### DIFF
--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -680,10 +680,6 @@
     <string name="hint_key">HEX, 6 bytes per line</string>
 
     <!-- Copy/Clone wizard messages -->
-    <string name="text_hold_existing_card">기존 카드를 기기에 대십시오</string>
-    <string name="text_copy_step1">원본 카드 읽기 완료</string>
-    <string name="text_modukey_present">모두키 카드를 기기에 대십시오</string>
-    <string name="text_copy_step2">카드에 쓰는 중…</string>
 
     <!-- Supported locales. No need for translation! -->
     <string-array name="supported_locales" translatable="false">


### PR DESCRIPTION
## Summary
- remove duplicate ModuKey wizard strings from `strings.xml`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684445b4c220832c99630a038750feec