### PR TITLE
Add NFC copy wizard activity

### DIFF
--- a/Mifare Classic Tool/app/build.gradle
+++ b/Mifare Classic Tool/app/build.gradle
@@ -19,10 +19,21 @@ android {
         generateLocaleConfig true
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
     buildTypes {
+        debug {
+            // Verbose logging for development builds
+            buildConfigField "boolean", "ENABLE_LOG", "true"
+            minifyEnabled false
+        }
         release {
             minifyEnabled false
             shrinkResources false
+            // Disable debug logs in release builds
+            buildConfigField "boolean", "ENABLE_LOG", "false"
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/Mifare Classic Tool/app/proguard-rules.pro
+++ b/Mifare Classic Tool/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Keep MifareClassic class referenced via reflection
+-keep class android.nfc.tech.MifareClassic { *; }

--- a/Mifare Classic Tool/app/src/main/AndroidManifest.xml
+++ b/Mifare Classic Tool/app/src/main/AndroidManifest.xml
@@ -213,6 +213,24 @@
             android:label="@string/title_activity_data_conversion_tool" >
         </activity>
 
+        <activity
+            android:name=".ui.copywizard.CopyWizardActivity"
+            android:configChanges="orientation|screenSize"
+            android:label="@string/title_activity_copy_wizard"
+            android:launchMode="singleTop" >
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.TECH_DISCOVERED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.action.TECH_DISCOVERED"
+                android:resource="@xml/nfc_copy_wizard_tech_filter" />
+        </activity>
+
     </application>
 
 </manifest>

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/domain/CopyWizardCoordinator.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/domain/CopyWizardCoordinator.java
@@ -1,0 +1,318 @@
+package de.syss.MifareClassicTool.domain;
+
+import android.content.Context;
+import android.nfc.Tag;
+import android.text.TextUtils;
+import android.util.Log;
+import android.util.SparseArray;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import de.syss.MifareClassicTool.BuildConfig;
+import de.syss.MifareClassicTool.Common;
+import de.syss.MifareClassicTool.MCReader;
+import de.syss.MifareClassicTool.R;
+
+/**
+ * Helper to read a tag using all available key files and save the dump.
+ */
+public class CopyWizardCoordinator {
+
+    private static final String TAG = "CopyWizardCoord";
+
+    private String mLastError;
+
+    public String getLastError() {
+        return mLastError;
+    }
+
+    /**
+     * Read the given tag and save the dump to internal storage.
+     * @param context Context for file and Toast operations.
+     * @param tag The tag to read.
+     * @return The created dump file or null on error.
+     */
+    public File readAndSaveDump(Context context, Tag tag) {
+        mLastError = null;
+        if (BuildConfig.ENABLE_LOG) {
+            Log.d(TAG, "readAndSaveDump invoked");
+        }
+        MCReader reader = MCReader.get(tag);
+        if (reader == null) {
+            mLastError = context.getString(R.string.copy_wizard_error_no_mfc_device);
+            return null;
+        }
+        File keyDir = Common.getFile(Common.KEYS_DIR);
+        File[] keyFiles = keyDir != null ? keyDir.listFiles(File::isFile) : null;
+        if (keyFiles == null || reader.setKeyFile(keyFiles, context) <= 0) {
+            int sc = reader.getSectorCount();
+            reader.close();
+            ArrayList<Integer> all = new ArrayList<>();
+            for (int i = 0; i < sc; i++) {
+                all.add(i);
+            }
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", all));
+            return null;
+        }
+        int sectorCount = reader.getSectorCount();
+        reader.setMappingRange(0, sectorCount - 1);
+        int status = 0;
+        while (status != -1 && status < sectorCount - 1) {
+            status = reader.buildNextKeyMapPart();
+        }
+        if (status == -1) {
+            reader.close();
+            ArrayList<Integer> all = new ArrayList<>();
+            for (int i = 0; i < sectorCount; i++) {
+                all.add(i);
+            }
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", all));
+            return null;
+        }
+        SparseArray<byte[][]> keyMap = reader.getKeyMap();
+        ArrayList<Integer> missing = new ArrayList<>();
+        for (int i = 0; i < sectorCount; i++) {
+            if (keyMap.get(i) == null) {
+                missing.add(i);
+            }
+        }
+        if (!missing.isEmpty()) {
+            reader.close();
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", missing));
+            return null;
+        }
+        SparseArray<String[]> raw = reader.readAsMuchAsPossible(keyMap);
+        reader.close();
+        if (raw == null) {
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", missing));
+            return null;
+        }
+        String uid = Common.bytes2Hex(tag.getId());
+        String ts = new SimpleDateFormat("yyyyMMdd_HHmm", Locale.getDefault()).format(new Date());
+        String name = "READ_" + ts + "_" + uid + ".mct";
+        File outFile = Common.getFile(Common.DUMPS_DIR + "/" + name);
+        if (outFile.getParentFile() != null) {
+            outFile.getParentFile().mkdirs();
+        }
+        String[] dump = buildDump(raw, sectorCount);
+        if (dump == null) {
+            return null;
+        }
+        if (Common.saveFile(outFile, dump, false)) {
+            return outFile;
+        }
+        mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                TextUtils.join(", ", missing));
+        return null;
+    }
+
+    /**
+     * Write the given dump to the target tag.
+     * @param context Context for file operations.
+     * @param tag Target tag.
+     * @param dumpFile Dump previously produced by {@link #readAndSaveDump}.
+     * @param enableManufacturerBlock If true, also try to write block 0.
+     * @return True on success.
+     */
+    public boolean writeClone(Context context, Tag tag, File dumpFile,
+                               boolean enableManufacturerBlock) {
+        mLastError = null;
+        if (BuildConfig.ENABLE_LOG) {
+            Log.d(TAG, "writeClone invoked");
+        }
+        String[] dump = Common.readFileLineByLine(dumpFile, false, context);
+        if (dump == null || Common.isValidDump(dump, false) != 0) {
+            mLastError = context.getString(R.string.copy_wizard_error_key_map, "?");
+            return false;
+        }
+        HashMap<Integer, HashMap<Integer, byte[]>> dumpWithPos =
+                parseDump(dump);
+        if (!enableManufacturerBlock) {
+            if (dumpWithPos.containsKey(0)) {
+                dumpWithPos.get(0).remove(0);
+                if (dumpWithPos.get(0).isEmpty()) {
+                    dumpWithPos.remove(0);
+                }
+            }
+        } else {
+            HashMap<Integer, byte[]> s0 = dumpWithPos.get(0);
+            if (s0 != null && s0.containsKey(0)) {
+                String block0 = Common.bytes2Hex(s0.get(0));
+                if (!checkBlock0(tag, block0)) {
+                    mLastError = context.getString(R.string.copy_wizard_error_tag_not_magic);
+                    return false;
+                }
+            }
+        }
+
+        MCReader reader = MCReader.get(tag);
+        if (reader == null) {
+            mLastError = context.getString(R.string.copy_wizard_error_no_mfc_device);
+            return false;
+        }
+        File keyDir = Common.getFile(Common.KEYS_DIR);
+        File[] keyFiles = keyDir != null ? keyDir.listFiles(File::isFile) : null;
+        if (keyFiles == null || reader.setKeyFile(keyFiles, context) <= 0) {
+            reader.close();
+            ArrayList<Integer> all = new ArrayList<>();
+            for (int i = 0; i < reader.getSectorCount(); i++) {
+                all.add(i);
+            }
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", all));
+            return false;
+        }
+        int sectorCount = reader.getSectorCount();
+        reader.setMappingRange(0, sectorCount - 1);
+        int status = 0;
+        while (status != -1 && status < sectorCount - 1) {
+            status = reader.buildNextKeyMapPart();
+        }
+        if (status == -1) {
+            reader.close();
+            ArrayList<Integer> all = new ArrayList<>();
+            for (int i = 0; i < sectorCount; i++) {
+                all.add(i);
+            }
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", all));
+            return false;
+        }
+        SparseArray<byte[][]> keyMap = reader.getKeyMap();
+        ArrayList<Integer> missing = new ArrayList<>();
+        for (int i = 0; i < sectorCount; i++) {
+            if (keyMap.get(i) == null) {
+                missing.add(i);
+            }
+        }
+        if (!missing.isEmpty()) {
+            reader.close();
+            mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                    TextUtils.join(", ", missing));
+            return false;
+        }
+
+        HashMap<Integer, int[]> pos = new HashMap<>();
+        for (Map.Entry<Integer, HashMap<Integer, byte[]>> e : dumpWithPos.entrySet()) {
+            Set<Integer> blocks = e.getValue().keySet();
+            int[] arr = new int[blocks.size()];
+            int idx = 0;
+            for (int b : blocks) {
+                arr[idx++] = b;
+            }
+            pos.put(e.getKey(), arr);
+        }
+
+        HashMap<Integer, HashMap<Integer, Integer>> writeOnPos =
+                reader.isWritableOnPositions(pos, keyMap);
+        if (writeOnPos == null) {
+            reader.close();
+            if (enableManufacturerBlock) {
+                mLastError = context.getString(R.string.copy_wizard_error_tag_not_magic);
+            } else {
+                mLastError = context.getString(R.string.copy_wizard_error_key_map,
+                        TextUtils.join(", ", missing));
+            }
+            return false;
+        }
+
+        for (int sector : writeOnPos.keySet()) {
+            byte[][] keys = keyMap.get(sector);
+            for (int block : writeOnPos.get(sector).keySet()) {
+                byte[] writeKey = null;
+                boolean useAsKeyB = true;
+                int wi = writeOnPos.get(sector).get(block);
+                if (wi == 1 || wi == 4) {
+                    writeKey = keys[0];
+                    useAsKeyB = false;
+                } else if (wi == 2 || wi == 5 || wi == 6) {
+                    writeKey = keys[1];
+                }
+                if (writeKey == null) {
+                    reader.close();
+                    return false;
+                }
+                byte[] data = dumpWithPos.get(sector).get(block);
+                int result = 0;
+                for (int i = 0; i < 2; i++) {
+                    result = reader.writeBlock(sector, block, data, writeKey, useAsKeyB);
+                    if (result == 0) {
+                        break;
+                    }
+                }
+                if (result != 0) {
+                    reader.close();
+                    if (enableManufacturerBlock && sector == 0 && block == 0) {
+                        mLastError = context.getString(R.string.copy_wizard_error_tag_not_magic);
+                    }
+                    return false;
+                }
+            }
+        }
+        reader.close();
+        return true;
+    }
+
+    private HashMap<Integer, HashMap<Integer, byte[]>> parseDump(String[] dump) {
+        HashMap<Integer, HashMap<Integer, byte[]>> ret = new HashMap<>();
+        int sector = 0;
+        int block = 0;
+        for (String line : dump) {
+            if (line.startsWith("+")) {
+                String[] tmp = line.split(": ");
+                sector = Integer.parseInt(tmp[tmp.length - 1]);
+                block = 0;
+                ret.put(sector, new HashMap<>());
+            } else if (!line.contains("-")) {
+                ret.get(sector).put(block++, Common.hex2Bytes(line));
+            } else {
+                block++;
+            }
+        }
+        return ret;
+    }
+
+    private boolean checkBlock0(Tag tag, String block0) {
+        int uidLen = tag.getId().length;
+        if (uidLen == 4) {
+            byte bcc = Common.hex2Bytes(block0.substring(8, 10))[0];
+            byte[] uid = Common.hex2Bytes(block0.substring(0, 8));
+            if (!Common.isValidBcc(uid, bcc)) {
+                return false;
+            }
+        }
+        MCReader tmp = MCReader.get(tag);
+        boolean valid = Common.isValidBlock0(block0, uidLen,
+                tmp != null ? tmp.getSize() : 0, true);
+        if (tmp != null) {
+            tmp.close();
+        }
+        return valid;
+    }
+
+    private String[] buildDump(SparseArray<String[]> rawDump, int sectorCount) {
+        ArrayList<String> tmpDump = new ArrayList<>();
+        for (int i = 0; i < sectorCount; i++) {
+            String[] val = rawDump.get(i);
+            tmpDump.add("+Sector: " + i);
+            if (val != null) {
+                Collections.addAll(tmpDump, val);
+            } else {
+                tmpDump.add("*No keys found or dead sector");
+            }
+        }
+        return tmpDump.toArray(new String[0]);
+    }
+}

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/ui/copywizard/CopyWizardActivity.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/ui/copywizard/CopyWizardActivity.java
@@ -1,0 +1,168 @@
+package de.syss.MifareClassicTool.ui.copywizard;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.nfc.NfcAdapter;
+import android.nfc.Tag;
+import android.nfc.tech.MifareClassic;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.TextView;
+import android.widget.Toast;
+import android.view.View;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.File;
+
+import de.syss.MifareClassicTool.Common;
+import de.syss.MifareClassicTool.R;
+import de.syss.MifareClassicTool.domain.CopyWizardCoordinator;
+
+public class CopyWizardActivity extends AppCompatActivity {
+    public static final int STEP_READ = 1;
+    public static final int STEP_WRITE = 2;
+
+    private int mState = STEP_READ;
+
+    private TextView mTopMessage;
+    private TextView mSubMessage;
+    private Button mPrimaryButton;
+    private Button mSecondaryButton;
+    private CheckBox mBlock0CheckBox;
+
+    private NfcAdapter mNfcAdapter;
+    private PendingIntent mPendingIntent;
+    private File mDumpFile;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_copy_wizard);
+
+        mTopMessage = findViewById(R.id.top_message);
+        mSubMessage = findViewById(R.id.sub_message);
+        mPrimaryButton = findViewById(R.id.primary_button);
+        mSecondaryButton = findViewById(R.id.secondary_button);
+        mBlock0CheckBox = findViewById(R.id.checkbox_block0);
+
+        mNfcAdapter = NfcAdapter.getDefaultAdapter(this);
+        Intent intent = new Intent(this, getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        int flags = PendingIntent.FLAG_MUTABLE;
+        mPendingIntent = PendingIntent.getActivity(this, 0, intent, flags);
+
+        mPrimaryButton.setOnClickListener(v -> {
+            if (mState == STEP_READ) {
+                // TODO: trigger read process
+            } else if (mState == STEP_WRITE) {
+                // TODO: trigger write process
+            }
+        });
+
+        mSecondaryButton.setOnClickListener(v -> {
+            if (mState == STEP_WRITE) {
+                mState = STEP_READ;
+                updateUi();
+            }
+        });
+
+        updateUi();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (mNfcAdapter != null) {
+            if (!mNfcAdapter.isEnabled()) {
+                Toast.makeText(this, R.string.copy_wizard_nfc_off, Toast.LENGTH_LONG).show();
+                startActivity(new Intent(Settings.ACTION_NFC_SETTINGS));
+            }
+            String[][] techList = new String[][] { new String[] { MifareClassic.class.getName() } };
+            mNfcAdapter.enableForegroundDispatch(this, mPendingIntent, null, techList);
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        if (mNfcAdapter != null) {
+            mNfcAdapter.disableForegroundDispatch(this);
+        }
+        super.onPause();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+        if (tag != null) {
+            handleTag(tag);
+        }
+    }
+
+    private void handleTag(Tag tag) {
+        if (mState == STEP_READ) {
+            String uid = Common.bytes2Hex(tag.getId());
+            mTopMessage.setText(getString(R.string.copy_wizard_uid_recognized, uid));
+            new Thread(() -> {
+                CopyWizardCoordinator coordinator = new CopyWizardCoordinator();
+                File file = coordinator.readAndSaveDump(this, tag);
+                String err = coordinator.getLastError();
+                if (file != null) {
+                    mDumpFile = file;
+                    runOnUiThread(() -> {
+                        mState = STEP_WRITE;
+                        updateUi();
+                    });
+                } else if (err != null) {
+                    runOnUiThread(() ->
+                            Toast.makeText(this, err, Toast.LENGTH_LONG).show());
+                }
+            }).start();
+        } else if (mState == STEP_WRITE && mDumpFile != null) {
+            if (!mBlock0CheckBox.isChecked()) {
+                Toast.makeText(this, R.string.copy_wizard_block0_consent_toast, Toast.LENGTH_LONG).show();
+                return;
+            }
+            mTopMessage.setText(R.string.copy_wizard_write_detected);
+            new Thread(() -> {
+                CopyWizardCoordinator coordinator = new CopyWizardCoordinator();
+                boolean success = coordinator.writeClone(this, tag, mDumpFile, mBlock0CheckBox.isChecked());
+                String err = coordinator.getLastError();
+                runOnUiThread(() -> {
+                    if (success) {
+                        Toast.makeText(this, R.string.copy_wizard_clone_finished, Toast.LENGTH_LONG).show();
+                    } else if (err != null) {
+                        Toast.makeText(this, err, Toast.LENGTH_LONG).show();
+                    }
+                    mState = STEP_READ;
+                    updateUi();
+                });
+            }).start();
+        }
+    }
+
+    private void updateUi() {
+        if (mState == STEP_READ) {
+            mTopMessage.setText(R.string.copy_wizard_read_top);
+            mSubMessage.setText(R.string.copy_wizard_read_sub);
+            mPrimaryButton.setText(R.string.copy_wizard_read_button);
+            mPrimaryButton.setEnabled(true);
+            mSecondaryButton.setText(R.string.copy_wizard_write_button);
+            mSecondaryButton.setEnabled(false);
+            mBlock0CheckBox.setVisibility(View.GONE);
+            mBlock0CheckBox.setChecked(false);
+        } else if (mState == STEP_WRITE) {
+            mTopMessage.setText(R.string.copy_wizard_write_top);
+            mSubMessage.setText(R.string.copy_wizard_write_sub);
+            mPrimaryButton.setText(R.string.copy_wizard_read_button);
+            mPrimaryButton.setEnabled(false);
+            mSecondaryButton.setText(R.string.copy_wizard_write_button);
+            mSecondaryButton.setEnabled(true);
+             mBlock0CheckBox.setVisibility(View.VISIBLE);
+             mBlock0CheckBox.setChecked(false);
+        }
+    }
+}
+

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_copy_wizard.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_copy_wizard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/top_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:id="@+id/sub_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:paddingBottom="16dp" />
+
+    <CheckBox
+        android:id="@+id/checkbox_block0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/copy_wizard_enable_block0"
+        android:layout_marginBottom="8dp" />
+
+    <Button
+        android:id="@+id/primary_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/secondary_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/Mifare Classic Tool/app/src/main/res/values-ko/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values-ko/strings.xml
@@ -8,4 +8,10 @@
     <string name="text_copy_step2">복사2단계 진행중</string>
     <string name="action_start_copy">복사시작</string>
     <string name="action_start_copy_step2">복사2단계 시작</string>
+    <string name="copy_wizard_enable_block0">제조사 블록 쓰기(UID 포함) 활성화 — 위험, 법적 준수/승인 환경에서만 사용</string>
+    <string name="copy_wizard_block0_consent_toast">제조사 블록 쓰기를 활성화하려면 동의 체크박스를 선택하세요</string>
+    <string name="copy_wizard_error_no_mfc_device">이 기기는 MIFARE Classic을 지원하지 않습니다.</string>
+    <string name="copy_wizard_error_tag_not_magic">이 태그는 UID 쓰기를 지원하지 않습니다(일반 카드).</string>
+    <string name="copy_wizard_error_key_map">다음 섹터 키 매핑에 실패했습니다: %1$s. 올바른 키 파일을 제공하세요.</string>
+    <string name="copy_wizard_nfc_off">NFC가 꺼져 있습니다. 설정에서 NFC를 켜세요.</string>
 </resources>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -689,6 +689,22 @@
     <string name="hint_key">HEX, 6 bytes per line</string>
 
     <!-- Copy/Clone wizard messages -->
+    <string name="title_activity_copy_wizard">복사 마법사</string>
+    <string name="copy_wizard_read_top">읽기 단계</string>
+    <string name="copy_wizard_read_sub">원본 태그를 기기 뒷면에 대세요</string>
+    <string name="copy_wizard_read_button">읽기</string>
+    <string name="copy_wizard_write_top">쓰기 단계</string>
+    <string name="copy_wizard_write_sub">대상 태그를 기기 뒷면에 대세요</string>
+    <string name="copy_wizard_write_button">쓰기</string>
+    <string name="copy_wizard_uid_recognized">UID : %1$s 카드키가 인식되었습니다. 1단계완료시까지 카드키를 떼지마세요</string>
+    <string name="copy_wizard_write_detected">인식되었습니다. 2단계완료시까지 떼지마세요</string>
+    <string name="copy_wizard_clone_finished">복사가 완료되었습니다.</string>
+    <string name="copy_wizard_enable_block0">제조사 블록 쓰기(UID 포함) 활성화 — 위험, 법적 준수/승인 환경에서만 사용</string>
+    <string name="copy_wizard_block0_consent_toast">제조사 블록 쓰기를 활성화하려면 동의 체크박스를 선택하세요</string>
+    <string name="copy_wizard_error_no_mfc_device">This device does not support MIFARE Classic.</string>
+    <string name="copy_wizard_error_tag_not_magic">This tag does not support UID writing (standard card).</string>
+    <string name="copy_wizard_error_key_map">Failed to map keys for sectors: %1$s. Please provide the correct key file.</string>
+    <string name="copy_wizard_nfc_off">NFC is turned off. Enable it in settings.</string>
 
     <!-- Supported locales. No need for translation! -->
     <string-array name="supported_locales" translatable="false">

--- a/Mifare Classic Tool/app/src/main/res/xml/nfc_copy_wizard_tech_filter.xml
+++ b/Mifare Classic Tool/app/src/main/res/xml/nfc_copy_wizard_tech_filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <tech-list>
+        <tech>android.nfc.tech.MifareClassic</tech>
+    </tech-list>
+</resources>

--- a/tests/CopyWizard_TestPlan.md
+++ b/tests/CopyWizard_TestPlan.md
@@ -1,0 +1,35 @@
+# CopyWizard Manual Test Plan
+
+## Preconditions
+- Android device with NFC support and MIFARE Classic capable.
+- Install debug build of the app (`assembleDebug`).
+- Prepare a writable MIFARE Classic tag and a second tag for cloning.
+- Place at least one valid key file in the app's keys directory.
+
+## Test Cases
+
+- [ ] **Step1 Read success**
+  1. Launch *CopyWizardActivity*.
+  2. Tap the primary button to start reading.
+  3. Tap source tag to device.
+  4. Verify toast/text shows `UID : {uid} 카드키가 인식되었습니다. 1단계완료시까지 카드키를 떼지마세요`.
+  5. Confirm the UI transitions to Step 2.
+
+- [ ] **Auto-save name pattern**
+  1. After Step 1 completes, using a file browser or `adb shell`, navigate to the app's internal dumps folder.
+  2. Confirm a file named `READ_yyyyMMdd_HHmm_{UID}.mct` exists and contains dump data.
+
+- [ ] **Step2 Write success**
+  1. On Step 2 screen, ensure manufacturer block checkbox is **unchecked**.
+  2. Tap the target tag and hold it until completion.
+  3. Verify message `복사가 완료되었습니다.` appears.
+  4. Remove tag and confirm data cloned (e.g., via ReadTag activity).
+
+- [ ] **Manufacturer block disabled**
+  1. With checkbox unchecked, ensure block 0 of target tag remains unchanged after writing.
+
+- [ ] **Manufacturer block enabled**
+  1. Enable checkbox `제조사 블록 쓰기(UID 포함) 활성화 — 위험, 법적 준수/승인 환경에서만 사용`.
+  2. Tap target tag again.
+  3. Confirm block 0 writes only if tag is magic; otherwise error `이 태그는 UID 쓰기를 지원하지 않습니다(일반 카드).` is shown.
+


### PR DESCRIPTION
## Summary
- add CopyWizardActivity with two-step NFC read/write flow
- wire foreground dispatch and intent filters for MifareClassic tags
- provide layout and Korean UI strings for the copy wizard
- programmatically read source tag using all key files and save dump
- support writing a saved dump back to another tag with optional manufacturer block
- gate cloning on an explicit consent checkbox before writing manufacturer block
- surface detailed errors for unsupported devices, missing keys, non-magic tags, and NFC off
- document manual test plan, add proguard rule for reflective MifareClassic access, and enable debug/release logging flavors

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5e399cc832c98bb001b1e0f6611