### PR TITLE
Align copy wizard with MODUKEY workflow

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/ui/copywizard/CopyWizardActivity.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/ui/copywizard/CopyWizardActivity.java
@@ -9,6 +9,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.View;
+import android.view.animation.AlphaAnimation;
+import android.view.animation.Animation;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.TextView;
@@ -32,6 +34,11 @@ public class CopyWizardActivity extends AppCompatActivity {
     private boolean autoMode = false;
     private AutoState autoState = AutoState.IDLE;
     private String lastSavedDumpPath = null;
+    private boolean hasSourceTag = false;
+    private boolean hasTargetTag = false;
+    private boolean isReadingInProgress = false;
+    private boolean isWritingInProgress = false;
+    private Animation blinkAnimation;
 
     private int mState = STEP_READ;
 
@@ -65,27 +72,19 @@ public class CopyWizardActivity extends AppCompatActivity {
         mPendingIntent = PendingIntent.getActivity(this, 0, intent, flags);
 
         mPrimaryButton.setOnClickListener(v -> {
-            if (mState == STEP_READ) {
-                // Auto-select all key files and start mapping+reading
+            if (mState == STEP_READ && hasSourceTag && !isReadingInProgress) {
                 selectAllKeyFiles();
                 startMappingAndReadTag();
-            } else if (mState == STEP_WRITE) {
-                if (!mBlock0CheckBox.isChecked()) {
-                    Toast.makeText(this, R.string.copy_wizard_block0_consent_toast, Toast.LENGTH_LONG).show();
-                    return;
-                }
-                writeDumpClone();
             }
         });
 
         mSecondaryButton.setOnClickListener(v -> {
-            if (mState == STEP_WRITE) {
-                mState = STEP_READ;
-                updateUi();
+            if (mState == STEP_WRITE && hasTargetTag && !isWritingInProgress) {
+                writeDumpClone();
             }
         });
 
-        updateUi();
+        updateUi(true);
     }
 
     @Override
@@ -132,18 +131,28 @@ public class CopyWizardActivity extends AppCompatActivity {
     }
 
     private void handleTag(Tag tag) {
-        currentTag = tag;
+        if (tag == null) {
+            return;
+        }
         if (mState == STEP_READ) {
-            String uid = Common.bytes2Hex(tag.getId());
-            mTopMessage.setText(getString(R.string.copy_wizard_uid_recognized, uid));
-            startMappingAndReadTag();
-        } else if (mState == STEP_WRITE && mDumpFile != null) {
-            if (!mBlock0CheckBox.isChecked()) {
-                Toast.makeText(this, R.string.copy_wizard_block0_consent_toast, Toast.LENGTH_LONG).show();
+            if (isReadingInProgress) {
                 return;
             }
-            mTopMessage.setText(R.string.copy_wizard_write_detected);
-            writeDumpClone();
+            currentTag = tag;
+            hasSourceTag = true;
+            String uid = Common.bytes2Hex(tag.getId());
+            mTopMessage.setText(getString(R.string.mct_uid_detected_step1, uid));
+            setSubMessage("", false);
+            updateUi(false);
+        } else if (mState == STEP_WRITE && mDumpFile != null) {
+            if (isWritingInProgress) {
+                return;
+            }
+            currentTag = tag;
+            hasTargetTag = true;
+            mTopMessage.setText(R.string.mct_detected_step2);
+            setSubMessage("", false);
+            updateUi(false);
         }
     }
 
@@ -152,31 +161,45 @@ public class CopyWizardActivity extends AppCompatActivity {
     }
 
     private void startMappingAndReadTag() {
-        if (currentTag == null) return;
+        if (currentTag == null || isReadingInProgress) {
+            return;
+        }
+        final Tag tag = currentTag;
+        isReadingInProgress = true;
+        setSubMessage(getString(R.string.mct_copy_step1_running), true);
         new Thread(() -> {
             CopyWizardCoordinator coordinator = new CopyWizardCoordinator();
-            File file = coordinator.readAndSaveDump(this, currentTag);
+            File file = coordinator.readAndSaveDump(this, tag);
             String err = coordinator.getLastError();
-            if (file != null) {
-                mDumpFile = file;
-                runOnUiThread(() -> {
+            runOnUiThread(() -> {
+                isReadingInProgress = false;
+                setSubMessage("", false);
+                if (file != null) {
+                    mDumpFile = file;
+                    lastSavedDumpPath = file.getAbsolutePath();
+                    currentTag = null;
+                    hasSourceTag = false;
                     mState = STEP_WRITE;
-                    updateUi();
+                    hasTargetTag = false;
+                    updateUi(true);
                     if (autoMode) {
-                        lastSavedDumpPath = file.getAbsolutePath();
                         autoState = AutoState.WAITING_MODUKEY;
-                        // Prompt user for the writable (MODUKEY) tag using existing strings
-                        mTopMessage.setText(R.string.copy_wizard_write_top);
                     }
-                });
-            } else if (err != null) {
-                runOnUiThread(() -> Toast.makeText(this, err, Toast.LENGTH_LONG).show());
-            }
+                } else {
+                    hasSourceTag = true;
+                    if (err != null) {
+                        Toast.makeText(this, err, Toast.LENGTH_LONG).show();
+                    }
+                    if (autoMode) {
+                        autoState = AutoState.IDLE;
+                    }
+                    updateUi(false);
+                }
+            });
         }).start();
     }
 
     private void enableWriteManufacturerBlock() {
-        mBlock0CheckBox.setVisibility(View.VISIBLE);
         mBlock0CheckBox.setChecked(true);
     }
 
@@ -185,40 +208,103 @@ public class CopyWizardActivity extends AppCompatActivity {
     }
 
     private void writeDumpClone() {
-        if (currentTag == null || mDumpFile == null) return;
+        if (currentTag == null || mDumpFile == null || isWritingInProgress) {
+            return;
+        }
+        final Tag tag = currentTag;
+        enableWriteManufacturerBlock();
+        isWritingInProgress = true;
+        setSubMessage(getString(R.string.mct_copy_step2_running), true);
         new Thread(() -> {
             CopyWizardCoordinator coordinator = new CopyWizardCoordinator();
-            boolean success = coordinator.writeClone(this, currentTag, mDumpFile, mBlock0CheckBox.isChecked());
+            boolean success = coordinator.writeClone(this, tag, mDumpFile, mBlock0CheckBox.isChecked());
             String err = coordinator.getLastError();
             runOnUiThread(() -> {
+                isWritingInProgress = false;
+                currentTag = null;
+                hasTargetTag = false;
+                setSubMessage("", false);
                 if (success) {
-                    Toast.makeText(this, R.string.copy_wizard_clone_finished, Toast.LENGTH_LONG).show();
+                    mTopMessage.setText(R.string.mct_copy_done);
+                    Toast.makeText(this, R.string.mct_copy_done, Toast.LENGTH_LONG).show();
+                    mState = STEP_READ;
+                    hasSourceTag = false;
+                    mDumpFile = null;
                     if (autoMode) {
                         autoState = AutoState.DONE;
                     }
-                } else if (err != null) {
-                    Toast.makeText(this, err, Toast.LENGTH_LONG).show();
+                    updateUi(false);
+                } else {
+                    if (err != null) {
+                        Toast.makeText(this, err, Toast.LENGTH_LONG).show();
+                    }
+                    mTopMessage.setText(R.string.mct_prompt_present_modukey);
+                    if (autoMode) {
+                        autoState = AutoState.WAITING_MODUKEY;
+                    }
+                    updateUi(false);
                 }
-                mState = STEP_READ;
-                updateUi();
             });
         }).start();
     }
 
+    private void setSubMessage(CharSequence text, boolean blink) {
+        if (text == null || text.length() == 0) {
+            mSubMessage.setText("");
+            mSubMessage.setVisibility(View.GONE);
+            stopBlinking();
+        } else {
+            mSubMessage.setText(text);
+            mSubMessage.setVisibility(View.VISIBLE);
+            if (blink) {
+                startBlinking();
+            } else {
+                stopBlinking();
+            }
+        }
+    }
+
+    private void startBlinking() {
+        if (blinkAnimation == null) {
+            blinkAnimation = new AlphaAnimation(1.0f, 0.2f);
+            blinkAnimation.setDuration(500);
+            blinkAnimation.setRepeatMode(Animation.REVERSE);
+            blinkAnimation.setRepeatCount(Animation.INFINITE);
+        }
+        mSubMessage.startAnimation(blinkAnimation);
+    }
+
+    private void stopBlinking() {
+        if (blinkAnimation != null) {
+            mSubMessage.clearAnimation();
+        }
+    }
+
     private void onTagDiscoveredAuto(Tag tag) {
+        if (tag == null) {
+            return;
+        }
+        if (isReadingInProgress || isWritingInProgress) {
+            return;
+        }
         currentTag = tag;
         switch (autoState) {
             case IDLE: {
+                hasSourceTag = true;
                 String uid = Common.bytes2Hex(tag.getId());
-                mTopMessage.setText(getString(R.string.copy_wizard_uid_recognized, uid));
+                mTopMessage.setText(getString(R.string.mct_uid_detected_step1, uid));
+                setSubMessage("", false);
+                updateUi(false);
                 selectAllKeyFiles();
                 startMappingAndReadTag();
                 autoState = AutoState.READING;
                 break;
             }
             case WAITING_MODUKEY: {
-                mTopMessage.setText(R.string.copy_wizard_write_detected);
-                enableWriteManufacturerBlock();
+                hasTargetTag = true;
+                mTopMessage.setText(R.string.mct_detected_step2);
+                setSubMessage("", false);
+                updateUi(false);
                 if (lastSavedDumpPath != null) {
                     selectDumpFile(lastSavedDumpPath);
                 }
@@ -232,25 +318,29 @@ public class CopyWizardActivity extends AppCompatActivity {
         }
     }
 
-    private void updateUi() {
+    private void updateUi(boolean resetMessages) {
         if (mState == STEP_READ) {
-            mTopMessage.setText(R.string.copy_wizard_read_top);
-            mSubMessage.setText(R.string.copy_wizard_read_sub);
-            mPrimaryButton.setText(R.string.copy_wizard_read_button);
-            mPrimaryButton.setEnabled(true);
-            mSecondaryButton.setText(R.string.copy_wizard_write_button);
+            mPrimaryButton.setVisibility(View.VISIBLE);
+            mPrimaryButton.setText(R.string.mct_copy_start);
+            mPrimaryButton.setEnabled(hasSourceTag && !isReadingInProgress);
+            mSecondaryButton.setVisibility(View.GONE);
             mSecondaryButton.setEnabled(false);
-            mBlock0CheckBox.setVisibility(View.GONE);
-            mBlock0CheckBox.setChecked(false);
+            if (resetMessages) {
+                mTopMessage.setText(R.string.mct_prompt_present_original);
+                setSubMessage("", false);
+            }
         } else if (mState == STEP_WRITE) {
-            mTopMessage.setText(R.string.copy_wizard_write_top);
-            mSubMessage.setText(R.string.copy_wizard_write_sub);
-            mPrimaryButton.setText(R.string.copy_wizard_read_button);
+            mPrimaryButton.setVisibility(View.GONE);
             mPrimaryButton.setEnabled(false);
-            mSecondaryButton.setText(R.string.copy_wizard_write_button);
-            mSecondaryButton.setEnabled(true);
-            mBlock0CheckBox.setVisibility(View.VISIBLE);
-            mBlock0CheckBox.setChecked(false);
+            mSecondaryButton.setVisibility(View.VISIBLE);
+            mSecondaryButton.setText(R.string.mct_copy_step2_start);
+            mSecondaryButton.setEnabled(hasTargetTag && !isWritingInProgress && mDumpFile != null);
+            if (resetMessages) {
+                mTopMessage.setText(R.string.mct_prompt_present_modukey);
+                setSubMessage("", false);
+            }
         }
+        mBlock0CheckBox.setVisibility(View.GONE);
+        mBlock0CheckBox.setChecked(true);
     }
 }

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_copy_wizard.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_copy_wizard.xml
@@ -16,15 +16,17 @@
         android:id="@+id/sub_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingBottom="16dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:paddingBottom="16dp" />
+        android:visibility="gone" />
 
     <CheckBox
         android:id="@+id/checkbox_block0"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:text="@string/copy_wizard_enable_block0"
-        android:layout_marginBottom="8dp" />
+        android:visibility="gone" />
 
     <Button
         android:id="@+id/primary_button"

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -716,12 +716,13 @@
         <item>简体中文 (zh)</item>
     </string-array>
 
-<string name="mct_prompt_present_original">기존 카드키를 스마트폰 뒷면에 인식한 채로 유지하세요</string>
-<string name="mct_uid_detected_step1">UID : %1$s 카드키가 인식되었습니다. 1단계완료시까지 카드키를 떼지마세요</string>
-<string name="mct_copy_start">복사시작</string>
-<string name="mct_copy_step1_running">복사1단계진행중</string>
-<string name="mct_prompt_present_modukey">모두키를 스마트폰 뒷면에 인식시켜주세요</string>
-<string name="mct_detected_step2">인식되었습니다. 2단계완료시까지 떼지마세요</string>
-<string name="mct_copy_step2_running">복사2단계진행중</string>
-<string name="mct_copy_done">복사가 완료되었습니다.</string>
+    <string name="mct_prompt_present_original">기존 카드키를 스마트폰 뒷면에 인식한 채로 유지하세요</string>
+    <string name="mct_uid_detected_step1">UID : %1$s 카드키가 인식되었습니다. 1단계완료시까지 카드키를 떼지마세요</string>
+    <string name="mct_copy_start">복사시작</string>
+    <string name="mct_copy_step1_running">복사1단계진행중</string>
+    <string name="mct_prompt_present_modukey">모두키를 스마트폰 뒷면에 인식시켜주세요</string>
+    <string name="mct_detected_step2">인식되었습니다. 2단계완료시까지 떼지마세요</string>
+    <string name="mct_copy_step2_start">복사2단계 시작</string>
+    <string name="mct_copy_step2_running">복사2단계진행중</string>
+    <string name="mct_copy_done">복사가 완료되었습니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
- restructure the copy wizard state machine so read/write buttons, NFC handling and auto mode messaging match the two-stage MODUKEY flow
- add blinking status feedback and automatic manufacturer-block enablement during both copy stages
- hide unused layout elements and add a localized label for the second-stage start button

## Testing
- ⚠️ `./gradlew lint` *(fails: Android SDK is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7d3de8d4832ca16bd932fe862f68